### PR TITLE
Stream game events to clients

### DIFF
--- a/protobufs/aomos/v1/game.proto
+++ b/protobufs/aomos/v1/game.proto
@@ -12,6 +12,10 @@ message Game {
   State state = 1;
 }
 
+message GameReady {}
+message GameStarted {}
+message GameStopped {}
+
 message GetGameRequest {}
 message GetGameResponse {
   Game game = 1;
@@ -23,8 +27,18 @@ message StartGameResponse {}
 message StopGameRequest {}
 message StopGameResponse {}
 
+message SubscribeEventsRequest {}
+message SubscribeEventsResponse {
+  oneof event {
+    GameReady game_ready = 1;
+    GameStarted game_started = 2;
+    GameStopped game_stopped = 3;
+  }
+}
+
 service GameService {
   rpc GetGame(GetGameRequest) returns (GetGameResponse);
   rpc StartGame(StartGameRequest) returns (StartGameResponse);
   rpc StopGame(StopGameRequest) returns (StopGameResponse);
+  rpc SubscribeEvents(SubscribeEventsRequest) returns (stream SubscribeEventsResponse);
 }


### PR DESCRIPTION
Server-side streaming of game events has been added to the Protocol
Buffers. The API now defines the game events, which the server can push
to clients through a server-side stream.